### PR TITLE
Sprint 6

### DIFF
--- a/idc/metadata_utils.py
+++ b/idc/metadata_utils.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2015-2020, Institute for Systems Biology
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+
+from idc_collections.models import SolrCollection
+from solr_helpers import *
+from django.conf import settings
+
+logger = logging.getLogger('main_logger')
+
+
+def get_collex_metadata(filters, fields, with_docs=True):
+    results = {'docs': None, 'facets': {}}
+
+    tcga_facet_attrs = SolrCollection.objects.get(name="tcga_clin_bios").get_collection_attr().values_list('name', flat=True)
+    tcia_facet_attrs = SolrCollection.objects.get(name="tcia_images").get_collection_attr().values_list('name', flat=True)
+
+    solr_query = build_solr_query(filters, with_tags_for_ex=True)
+    query_set = []
+    for attr in solr_query['queries']:
+        if attr in tcga_facet_attrs:
+            query_set.append("{!join from=case_barcode fromIndex=tcga_clin_bios to=case_barcode}" + solr_query['queries'][attr])
+        else:
+            query_set.append(solr_query['queries'][attr])
+
+    solr_facets = build_solr_facets(list(tcia_facet_attrs), solr_query['filter_tags'])
+
+    solr_result = query_solr_and_format_result({
+        'collection': 'tcia_images',
+        'fields': fields,
+        'fqs': query_set,
+        'query_string': "*:*",
+        'facets': solr_facets,
+        'limit': 10,
+        'collapse_on': 'case_barcode',
+        'counts_only': False
+    })
+
+    results['docs'] = solr_result['docs']
+    results['facets']['cross_collex'] = solr_result['facets']
+    results['total'] = solr_result['numFound']
+
+    solr_facets = build_solr_facets(list(["vital_status","sample_type"]), solr_query['filter_tags'])
+
+    query_set = []
+    for attr in solr_query['queries']:
+        if attr in tcia_facet_attrs:
+            query_set.append(
+                "{!join from=case_barcode fromIndex=tcia_images to=case_barcode}" + solr_query['queries'][attr])
+        else:
+            query_set.append(solr_query['queries'][attr])
+
+    solr_result = query_solr_and_format_result({
+        'collection': 'tcga_clin_bios',
+        'fields': None,
+        'fqs': query_set,
+        'query_string': "*:*",
+        'facets': solr_facets,
+        'limit': 0,
+        'collapse_on': 'case_barcode',
+        'counts_only': True
+    })
+
+    results['facets']['collex'] = solr_result['facets']
+
+    return results

--- a/idc/settings.py
+++ b/idc/settings.py
@@ -83,8 +83,9 @@ SERVICE_ACCOUNT_LOG_NAME = os.environ.get('SERVICE_ACCOUNT_LOG_NAME', 'local_dev
 WEBAPP_LOGIN_LOG_NAME = os.environ.get('WEBAPP_LOGIN_LOG_NAME', 'local_dev_logging')
 GCP_ACTIVITY_LOG_NAME = os.environ.get('GCP_ACTIVITY_LOG_NAME', 'local_dev_logging')
 
-BASE_URL                = os.environ.get('BASE_URL', 'https://mvm-dot-idc.appspot.com')
-BASE_API_URL            = os.environ.get('BASE_API_URL', 'https://mvm-api-dot-idc.appspot.com')
+BASE_URL                = os.environ.get('BASE_URL', 'https://idc-dev.appspot.com')
+BASE_API_URL            = os.environ.get('BASE_API_URL', 'https://api-dot-idc-dev.appspot.com')
+API_HOST                = os.environ.get('API_HOST', 'api-dot-idc-dev.appspot.com')
 
 # Compute services - Should not be necessary in webapp
 PAIRWISE_SERVICE_URL    = os.environ.get('PAIRWISE_SERVICE_URL', None)

--- a/idc/settings.py
+++ b/idc/settings.py
@@ -532,6 +532,7 @@ SOLR_URI = os.environ.get('SOLR_URI', '')
 SOLR_LOGIN = os.environ.get('SOLR_LOGIN', '')
 SOLR_PASSWORD = os.environ.get('SOLR_PASSWORD', '')
 SOLR_CERT = join(dirname(dirname(__file__)), "{}{}".format(SECURE_LOCAL_PATH, os.environ.get('SOLR_CERT', '')))
+DEFAULT_FETCH_COUNT = os.environ.get('DEFAULT_FETCH_COUNT', 10)
 
 ##############################################################
 #   MailGun Email Settings

--- a/idc/views.py
+++ b/idc/views.py
@@ -44,8 +44,7 @@ from cohorts.models import Cohort, Cohort_Perms
 from idc_collections.models import Program
 from allauth.socialaccount.models import SocialAccount
 from django.http import HttpResponse, JsonResponse
-from solr_helpers import query_solr_and_format_result, build_solr_facets, build_solr_query
-from idc_collections.models import Attribute, SolrCollection
+from .metadata_utils import get_collex_metadata
 
 debug = settings.DEBUG
 logger = logging.getLogger('main_logger')
@@ -117,45 +116,20 @@ def css_test(request):
 # Returns the data exploration and filtering page, which also allows for cohort creation
 @login_required
 def explore_data(request):
-    filters = {"disease_code": ["BRCA","LUAD"]}
-    tcia_attrs = SolrCollection.objects.get(name="tcia_images").get_collection_attr().values_list('name', flat=True)
-    tcia_fields = SolrCollection.objects.get(name="tcia_images").get_collection_attr(False).values_list('name', flat=True)
-    tcga_attrs = SolrCollection.objects.get(name="tcga_clin_bios").get_collection_attr().values_list('name', flat=True)
+    filters = {"vital_status": ["Alive"]}
+    fields = ["BodyPartExamined", "Modality", "StudyDescription", "StudyInstanceUID", "SeriesInstanceUID"]
 
-    solr_query_str = build_solr_query(filters)
-    solr_facets = build_solr_facets(list(tcia_attrs), filters)
+    facets_and_lists = get_collex_metadata(filters, fields)
 
-    print("TCIA ATTRs: {}".format(tcia_attrs))
-    print("TCIA facets: {}".format(solr_facets))
+    if facets_and_lists:
 
-    solr_result = query_solr_and_format_result({
-        'collection': 'tcia_images',
-        'fields': list(tcia_fields),
-        'fq_string': '{!join from=case_barcode fromIndex=tcga_clin_bios to=case_barcode}' + solr_query_str,
-        'query_string': "*:*",
-        'facets': solr_facets,
-        'limit': 5,
-        'collapse_on': 'case_barcode',
-        'counts_only': False
-    })
-
-    print("Solr result: {}".format(solr_result))
-
-    solr_facets = build_solr_facets(list(tcga_attrs), filters)
-
-    solr_result = query_solr_and_format_result({
-        'collection': 'tcga_clin_bios',
-        'fields': None,
-        'fq_string': '{!join from=case_barcode fromIndex=tcia_images to=case_barcode}' + solr_query_str,
-        'query_string': "*:*",
-        'facets': solr_facets,
-        'limit': 0,
-        'collapse_on': 'case_barcode'
-    })
-
-    print("Solr result: {}".format(solr_result))
-
-    return render(request, 'idc/explore.html', {'request': request})
+        return render(request, 'idc/explore.html', {'request': request, 'context': {
+            'collex_attr_counts': facets_and_lists['facets']['collex'],
+            'cross_collex_attr_counts': facets_and_lists['facets']['cross_collex'],
+            'listings': facets_and_lists['docs']
+        }})
+    else:
+        return render(request, 'idc/explore.html', {'request': request})
 
 
 '''
@@ -366,68 +340,6 @@ def dicom(request, study_uid=None):
     }
     return render(request, template, context)
 
-
-@login_required
-def camic(request, file_uuid=None):
-    if debug: logger.debug('Called ' + sys._getframe().f_code.co_name)
-    context = {}
-
-    if not file_uuid:
-        messages.error("Error while attempting to display this pathology image: a file UUID was not provided.")
-        return redirect(reverse('cohort_list'))
-
-    images = [{'file_uuid': file_uuid, 'thumb': '', 'type': ''}]
-    template = 'idc/camic_single.html'
-
-    context['files'] = images
-    context['camic_viewer'] = settings.CAMIC_VIEWER
-    context['img_thumb_url'] = settings.IMG_THUMBS_URL
-
-    return render(request, template, context)
-
-
-@login_required
-def igv(request, sample_barcode=None, readgroupset_id=None):
-    if debug: logger.debug('Called '+sys._getframe().f_code.co_name)
-
-    readgroupset_list = []
-    bam_list = []
-
-    checked_list = json.loads(request.POST.__getitem__('checked_list'))
-    build = request.POST.__getitem__('build')
-
-    for item in checked_list['gcs_bam']:
-        bam_item = checked_list['gcs_bam'][item]
-        id_barcode = item.split(',')
-        bam_list.append({
-            'sample_barcode': id_barcode[1], 'gcs_path': id_barcode[0], 'build': build, 'program': bam_item['program']
-        })
-
-    context = {
-        'readgroupset_list': readgroupset_list,
-        'bam_list': bam_list,
-        'base_url': settings.BASE_URL,
-        'service_account': settings.WEB_CLIENT_ID,
-        'build': build,
-    }
-
-    return render(request, 'idc/igv.html', context)
-
-
-@login_required
-def path_report(request, report_file=None):
-    if debug: logger.debug('Called ' + sys._getframe().f_code.co_name)
-    context = {}
-
-    if not path_report:
-        messages.error("Error while attempting to display this pathology report: a report file name was not provided.")
-        return redirect(reverse('cohort_list'))
-
-    template = 'idc/path-pdf.html'
-
-    context['path_report_file'] = report_file
-
-    return render(request, template, context)
 
 
 # Because the match for vm_ is always done regardless of its presense in the URL


### PR DESCRIPTION
- Added a new module, metadata_utils, which will be used for all metadata gathering operations involing BQ or solr
- Updated explore_data example code to use get_collex_metadata