### PR TITLE
Sprint 21 gw

### DIFF
--- a/idc/urls.py
+++ b/idc/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
 
     url(r'^help/', views.help_page, name='help'),
     url(r'^explore/', views.explore_data_page, name='explore_data'),
+    url(r'^tables/', views.populate_tables, name='populate_tables'),
     url(r'^explore_demo/', demo_views.explore_demo_page, name='explore_demo'),
 
     #url(r'^test/', views.test, name='test'),

--- a/idc/views.py
+++ b/idc/views.py
@@ -240,7 +240,24 @@ def help_page(request):
 def quota_page(request):
     return render(request, 'idc/quota.html', {'request': request, 'quota': settings.IMG_QUOTA})
 
+def populate_tables(request):
 
+    table_data = {}
+    try:
+        req = request.GET if request.GET else request.POST
+        path_arr = [nstr for nstr in request.path.split('/') if nstr]
+        table_type = path_arr[len(path_arr)-1]
+        filters = json.loads(req.get('filters', '{}'))
+        i=1
+
+    except Exception as e:
+        logger.error("[ERROR] While attempting to populate the table:")
+        logger.exception(e)
+        messages.error(request,"Encountered an error when attempting to populate the page - please contact the administrator.")
+
+
+    i=1
+    return JsonResponse(table_data)
 
 # Data exploration and cohort creation page
 @login_required

--- a/idc/views.py
+++ b/idc/views.py
@@ -350,7 +350,7 @@ def populate_tables(request):
     return JsonResponse({"res":tableRes})
 
 # Data exploration and cohort creation page
-@login_required
+#@login_required
 def explore_data_page(request):
     attr_by_source = {}
     attr_sets = {}

--- a/idc/views.py
+++ b/idc/views.py
@@ -32,7 +32,7 @@ from django.contrib import messages
 
 from google_helpers.stackdriver import StackDriverLogger
 from cohorts.models import Cohort, Cohort_Perms
-from idc_collections.models import Program, DataSource, Collection, ImagingDataCommonsVersion
+from idc_collections.models import Program, DataSource, Collection, ImagingDataCommonsVersion, DataSetType
 from idc_collections.collex_metadata_utils import build_explorer_context
 from .models import AppInfo
 from allauth.socialaccount.models import SocialAccount
@@ -241,13 +241,23 @@ def quota_page(request):
     return render(request, 'idc/quota.html', {'request': request, 'quota': settings.IMG_QUOTA})
 
 def populate_tables(request):
-
     table_data = {}
     try:
         req = request.GET if request.GET else request.POST
         path_arr = [nstr for nstr in request.path.split('/') if nstr]
         table_type = path_arr[len(path_arr)-1]
         filters = json.loads(req.get('filters', '{}'))
+        table_data = get_table_data(filters, table_type)
+        #customFacets = {'uStudy':{'type': 'terms', 'field': 'PatientID', 'limit': -1, 'missing': True, 'facet': {'unique_count': 'unique(StudyInstanceUID)'}}}
+        '''sources = sources or DataSetType.objects.get(data_type=DataSetType.IMAGE_DATA).datasource_set.filter(
+            id__in=cohort.get_data_versions().get_data_sources(
+                source_type=DataSource.SOLR, aggregate_level="StudyInstanceUID"
+            ))'''
+
+        '''result = get_collex_metadata(filters, None, sources=sources, facets=["collection_id"], counts_only=True,
+                                     totals=["PatientID", "StudyInstanceUID", "SeriesInstanceUID"],
+                                     filtered_needed=False)'''
+
         i=1
 
     except Exception as e:

--- a/idc/views.py
+++ b/idc/views.py
@@ -350,7 +350,7 @@ def populate_tables(request):
     return JsonResponse({"res":tableRes})
 
 # Data exploration and cohort creation page
-#@login_required
+@login_required
 def explore_data_page(request):
     attr_by_source = {}
     attr_sets = {}

--- a/static/css/cohort-list.css
+++ b/static/css/cohort-list.css
@@ -1,0 +1,16 @@
+.ui-dialog {
+    position:fixed;
+    height: auto;
+    width:400px;
+    top:50%;
+    left:50%;
+}
+
+.ui-dialog-content {
+    display:inline-block;
+    width:auto;
+    min-height:90px;
+    max-height:none;
+    height:auto;
+
+}

--- a/static/css/search.css
+++ b/static/css/search.css
@@ -412,3 +412,21 @@ table {
 svg {
     overflow:visible;
 }
+
+#Program .more-checks:after {
+    content: "";
+    display:table;
+    clear: both;
+}
+
+#Program_list:after {
+    content: "";
+    display:table;
+    clear: both;
+}
+
+.list-group-item__heading:after {
+    content: "";
+    display:table;
+    clear: both;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -330,7 +330,8 @@ nav {
   display: block; }
 
 .float-right {
-  float: right; }
+  float: right;
+   }
 
 .float-left {
   float: left; }

--- a/static/js/cohorts/cohort-list.js
+++ b/static/js/cohorts/cohort-list.js
@@ -537,17 +537,7 @@ require([
                 $('#version_d').find('.series_o')[0].innerHTML=series_col;
                 $('#version_d').find('.series_c')[0].innerHTML=data['SeriesInstanceUID'].toString();
 
-               /*
-               ntxt += "<table class='table'><tr><th></th><th>Original Version</th><th>Current Version</th></tr>";
-               ntxt += "<tr><td># Cases</td> <td>"+case_col+"</td> <td>"+data['PatientID'].toString()+"</td> </tr>";
-               ntxt += "<tr><td># Studies</td> <td>"+study_col+"</td> <td>"+data['StudyInstanceUID'].toString()+"</td> </tr>";
-               ntxt += "<tr><td># Series</td> <td>"+series_col+"</td> <td>"+data['SeriesInstanceUID'].toString()+"</td> </tr>";
-               ntxt += "</table> <br>"
-               ntxt += "<button onclick=\"location.href = '/explore/?cohort_id="+id+"';\">Load New Version</button>"
 
-               $("#dialog-1")[0].innerHTML = ntxt;
-               $("#dialog-1").dialog('option','title','Comparing Versions of Cohort '+id);
-               $("#dialog-1").dialog('open'); */
                $('.spinner').hide();
             },
             error: function () {
@@ -559,9 +549,6 @@ require([
 
     $(document).ready(function () {
         $('#version_d').hide();
-        //$( "#dialog-1" ).dialog();
-        //$( "#dialog-1" ).dialog("option","width", 400);
-        //$( "#dialog-1" ).dialog('close');
-
+        
     });
 });

--- a/static/js/cohorts/cohort-list.js
+++ b/static/js/cohorts/cohort-list.js
@@ -513,6 +513,7 @@ require([
         let url = '/cohorts/'+id+'/stats/?update=true'
         url = encodeURI(url);
         var ntxt="";
+        $('#version_d').find('#ui-id-1')[0].innerHTML='Comparing Versions of Cohort '+id;
         $('.spinner').show();
         $.ajax({
             url: url,
@@ -520,6 +521,23 @@ require([
             type: 'get',
             contentType: 'application/x-www-form-urlencoded',
             success: function (data) {
+                $('#version_d').show();
+                var pageWidth = window.innerWidth;
+                var pageHeight = window.innerHeight;
+                var myElementWidth = document.getElementById('version_d').offsetWidth;
+                var myElementHeight = document.getElementById('version_d').offsetHeight;
+                document.getElementById('version_d').style.top = (pageHeight / 2) - (myElementHeight / 2) + "px";
+                document.getElementById('version_d').style.left = (pageWidth / 2) - (myElementWidth / 2) + "px";
+                $('#version_d').find('.case_o')[0].innerHTML=case_col;
+                $('#version_d').find('.case_c')[0].innerHTML=data['PatientID'].toString();
+
+                $('#version_d').find('.study_o')[0].innerHTML=study_col;
+                $('#version_d').find('.study_c')[0].innerHTML=data['StudyInstanceUID'].toString();
+
+                $('#version_d').find('.series_o')[0].innerHTML=series_col;
+                $('#version_d').find('.series_c')[0].innerHTML=data['SeriesInstanceUID'].toString();
+
+               /*
                ntxt += "<table class='table'><tr><th></th><th>Original Version</th><th>Current Version</th></tr>";
                ntxt += "<tr><td># Cases</td> <td>"+case_col+"</td> <td>"+data['PatientID'].toString()+"</td> </tr>";
                ntxt += "<tr><td># Studies</td> <td>"+study_col+"</td> <td>"+data['StudyInstanceUID'].toString()+"</td> </tr>";
@@ -529,7 +547,7 @@ require([
 
                $("#dialog-1")[0].innerHTML = ntxt;
                $("#dialog-1").dialog('option','title','Comparing Versions of Cohort '+id);
-               $("#dialog-1").dialog('open');
+               $("#dialog-1").dialog('open'); */
                $('.spinner').hide();
             },
             error: function () {
@@ -540,9 +558,10 @@ require([
     }
 
     $(document).ready(function () {
-        $( "#dialog-1" ).dialog();
-        $( "#dialog-1" ).dialog("option","width", 400);
-        $( "#dialog-1" ).dialog('close');
+        $('#version_d').hide();
+        //$( "#dialog-1" ).dialog();
+        //$( "#dialog-1" ).dialog("option","width", 400);
+        //$( "#dialog-1" ).dialog('close');
 
     });
 });

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -49,28 +49,30 @@ require([
             '#search_related_set .search-checkbox-list input:checked, ' +
             '#search_derived_set .search-checkbox-list input:checked').each(function(){
 
-            let modal_filter_block = '';
-            if($(this).parents('#program_set').length > 0) {
-                modal_filter_block = '#selected-filters-prog-set';
-            } else if($(this).parents('#search_orig_set').length > 0) {
-                modal_filter_block = '#selected-filters-orig-set';
-            } else if($(this).parents('#search_related_set').length > 0) {
-                modal_filter_block = '#selected-filters-rel-set';
-            } else if($(this).parents('#search_derived_set').length > 0) {
-                modal_filter_block = '#selected-filters-der-set';
-            }
+            if (!$(this).hasClass('hide-zeros')) {
+                let modal_filter_block = '';
+                if ($(this).parents('#program_set').length > 0) {
+                    modal_filter_block = '#selected-filters-prog-set';
+                } else if ($(this).parents('#search_orig_set').length > 0) {
+                    modal_filter_block = '#selected-filters-orig-set';
+                } else if ($(this).parents('#search_related_set').length > 0) {
+                    modal_filter_block = '#selected-filters-rel-set';
+                } else if ($(this).parents('#search_derived_set').length > 0) {
+                    modal_filter_block = '#selected-filters-der-set';
+                }
 
-            if($(`${modal_filter_block} p.`+$(this).data('filter-attr-id')).length <= 0) {
-                $(`${modal_filter_block}`).append('<p class="cohort-filter-display '+$(this).data('filter-attr-id')
-                    +'"><span class="attr">'+$(this).data('filter-display-attr')+':</span></p>');
+                if ($(`${modal_filter_block} p.` + $(this).data('filter-attr-id')).length <= 0) {
+                    $(`${modal_filter_block}`).append('<p class="cohort-filter-display ' + $(this).data('filter-attr-id')
+                        + '"><span class="attr">' + $(this).data('filter-display-attr') + ':</span></p>');
+                }
+                $(`${modal_filter_block} p.` + $(this).data('filter-attr-id')).append(
+                    '<span class="val">' + $(this).data('filter-display-val') + '</span>'
+                );
+                if (!filters[$(this).data('filter-attr-id')]) {
+                    filters[$(this).data('filter-attr-id')] = [];
+                }
+                filters[$(this).data('filter-attr-id')].push($(this).prop('value'));
             }
-             $(`${modal_filter_block} p.`+$(this).data('filter-attr-id')).append(
-                 '<span class="val">'+$(this).data('filter-display-val')+'</span>'
-             );
-            if(!filters[$(this).data('filter-attr-id')]) {
-                filters[$(this).data('filter-attr-id')] = [];
-            }
-            filters[$(this).data('filter-attr-id')].push($(this).prop('value'));
         });
 
         $('.ui-slider').each(function() {

--- a/static/js/image_search.js
+++ b/static/js/image_search.js
@@ -290,9 +290,13 @@ require([
             if (oStringA.length > 0) {
                 var oString = oStringA.join(" AND");
                 document.getElementById("search_def").innerHTML = '<p>' + oString + '</p>';
+                 document.getElementById('filt_txt').value=oString;
             } else {
                 document.getElementById("search_def").innerHTML = '<span class="placeholder">&nbsp;</span>';
+                 document.getElementById('filt_txt').value="";
             }
+
+
 
             //alert(oString);
         };
@@ -884,7 +888,7 @@ require([
 
             })
             if (addRow){
-                if (numArr < 2000){
+                if (numArr < 3000){
                     //$(selRows).addClass('selected_grey');
                     if (type ==='projects') {
                         addCases(curArr, "cases_table", false);
@@ -1678,7 +1682,8 @@ require([
 
         var updateFacetsData = function (newFilt) {
             changeAjax(true);
-            var url = '/explore/?counts_only=True&is_json=true&is_dicofdic=True&data_source_type=' + ($("#data_source_type option:selected").val() || 'S');
+            //var url = '/explore/?counts_only=True&is_json=true&is_dicofdic=True&data_source_type=' + ($("#data_source_type option:selected").val() || 'S');
+            var url = '/explore/'
             var parsedFiltObj=parseFilterObj();
             if (Object.keys(parsedFiltObj).length > 0) {
                  url += '&filters=' + JSON.stringify(parsedFiltObj);
@@ -1686,11 +1691,15 @@ require([
             }
 
             url = encodeURI(url);
+            url= encodeURI('/explore/')
+
+            ndic={'counts_only':'True', 'is_json':'True', 'is_dicofdic':'True', 'data_source_type':($("#data_source_type option:selected").val() || 'S'), 'filters':JSON.stringify(parsedFiltObj) }
             let deferred = $.Deferred();
             $.ajax({
                 url: url,
+                data: ndic,
                 dataType: 'json',
-                type: 'get',
+                type: 'post',
                 contentType: 'application/x-www-form-urlencoded',
                 success: function (data) {
                     var isFiltered = Boolean($('#search_def p').length>0);

--- a/static/js/image_search.js
+++ b/static/js/image_search.js
@@ -2866,7 +2866,7 @@ require([
         // For collection list
         $('.collection-list').each(function() {
             var $group = $(this);
-            var checkboxes = $group.find("input:checked");
+            var checkboxes = $group.find("input:checked").not(".hide-zeros");
             if (checkboxes.length > 0) {
                 var values = [];
                 var my_id = "";

--- a/static/js/image_search.js
+++ b/static/js/image_search.js
@@ -785,14 +785,17 @@ require([
         }
 
         window.toggleRows = function (row, type,prefix,justClickedPlus) {
+
             var justClickedIndex=-1;
             var selRows = new Array();
             var addRow= true;
+            var justAddedRows = new Array();
 
             if ($(row).parent().is('thead')){
                 selRows= getSelRows(row);
                 addRow = justClickedPlus;
             }
+
             else{
                 selRows=[$(row).index(),$(row).index()];
                 justClickedIndex=selRows[0];
@@ -818,11 +821,12 @@ require([
                 }
 
                 if  ( addRow  &&  ((thisInd ===justClickedIndex) || !($(this).find('input:checkbox')[0]).checked )) {
+                    $(this).addClass('tryToAdd')
                     if (!(thisInd ===justClickedIndex) ) {
                         $(this).find('input:checkbox')[0].checked=true;
                     }
                     curArr.push(curId);
-                    numArr+= parseInt($(this).find('.projects_table_num_cohort, .numcases')[0].innerHTML);
+                    numArr+= parseInt($(this).find('.projects_table_num_cohort, .numrows')[0].innerHTML);
                     if (type==='cases') {
                         var projectId = $(this).attr('data-projectid');
                         if (!(projectId in selDic)){
@@ -878,8 +882,8 @@ require([
 
             })
             if (addRow){
-                if (numArr < 3000){
-                    //$(selRows).addClass('selected_grey');
+                if (numArr <= 3000){
+                    $(selRows).removeClass('tryToAdd');
                     if (type ==='projects') {
                         addCases(curArr, "cases_table", false);
                     }
@@ -892,7 +896,11 @@ require([
 
                 }
                 else{
-                    alert('Sorry only 2000 or less rows can be fetched at once. You have selected '+numArr.toString()+' rows.')
+                    $(selRows).filter('.tryToAdd').find('input:checkbox').each(function(){
+                        this.checked=false;
+                    });
+                    alert('Sorry only 3000 or less rows can be fetched at once. You have selected '+numArr.toString()+' rows.')
+                    $(selRows).removeClass('.tryToAdd');
                 }
             }
         }
@@ -1032,12 +1040,19 @@ require([
             var fieldStr = JSON.stringify(fields);
             //var sortOnStr = JSON.stringify(sort_on);
             var uniques = JSON.stringify(["PatientID","StudyInstanceUID","SeriesInstanceUID"]);
-            let url = '/explore/?counts_only=False&is_json=True&with_clinical=True&collapse_on=' + collapse_on + '&filters=' + filterStr + '&fields=' + fieldStr + '&order_docs=' + orderDocStr+'&uniques='+uniques;
+            let url = '/explore/'
             url = encodeURI(url);
+            ndic= {'counts_only':'False', 'is_json':'True', 'with_clinical':'True', 'collapse_on':collapse_on, 'filters':filterStr, 'fields':fieldStr, 'order_docs':orderDocStr, 'uniques':uniques}
+                //?counts_only=False&is_json=True&with_clinical=True&collapse_on=' + collapse_on + '&filters=' + filterStr + '&fields=' + fieldStr + '&order_docs=' + orderDocStr+'&uniques='+uniques;
+            if (typeof(window.csr) !=='undefined'){
+                ndic['csrfmiddlewaretoken'] = window.csr
+            }
+
             $.ajax({
                 url: url,
                 dataType: 'json',
-                type: 'get',
+                type: 'post',
+                data: ndic,
                 contentType: 'application/x-www-form-urlencoded',
                 success: function (data) {
 
@@ -1081,12 +1096,12 @@ require([
                         var newHtml = '';
                         var rowId = 'case_' + patientId.replace(/\./g, '-');
 
-                        newHtml = '<tr id="' + rowId + '" data-projectid="' + projectId + '" class="' + pclass + ' text_head" onclick="(toggleRows(this, \'cases\', \'case_\', false))">' +
-                                   '<td class="ckbx"><input type="checkbox"></td>'+
+                        newHtml = '<tr id="' + rowId + '" data-projectid="' + projectId + '" class="' + pclass + ' text_head" >' +
+                                   '<td class="ckbx"><input type="checkbox" onclick="(toggleRows($(this).parent().parent(), \'cases\', \'case_\', false))"></td>'+
                                    '<td class="col1 project-name">' + projectNm + '</td>' +
                                     '<td class="col1 case-id">' + patientId +'</td>' +
-                                    '<td class="col1">' + numStudy.toString() + '</td>' +
-                                    '<td class="col1 numcases">' + numSeries.toString() + '</td>' +
+                                    '<td class="col1 numrows">' + numStudy.toString() + '</td>' +
+                                    '<td class="col1 ">' + numSeries.toString() + '</td>' +
                                     '</tr>';
 
 
@@ -1193,19 +1208,26 @@ require([
             var fieldStr = JSON.stringify(fields);
             var sortDocStr = JSON.stringify(sort_on);
 
+            let url = '/explore/';
+                //?counts_only=False&is_json=True&with_clinical=True&collapse_on=' + collapse_on + '&filters=' + filterStr + '&fields=' + fieldStr + '&sort_on=' + sortDocStr;
 
 
-            let url = '/explore/?counts_only=False&is_json=True&with_clinical=True&collapse_on=' + collapse_on + '&filters=' + filterStr + '&fields=' + fieldStr + '&sort_on=' + sortDocStr;
+            ndic={'counts_only':'False', 'is_json':'True', 'with_clinical':'True', 'filters': filterStr, 'collapse_on':collapse_on, 'fields':fieldStr, 'sort_on':sortDocStr }
+            if (typeof(window.csr) !=='undefined'){
+                ndic['csrfmiddlewaretoken'] = window.csr
+            }
             if (!isSeries){
                 var uniques = JSON.stringify(["StudyInstanceUID","SeriesInstanceUID"]);
-                url+='&uniques='+uniques;
+                ndic['uniques']=uniques;
             }
+
 
             url = encodeURI(url);
             $.ajax({
                 url: url,
                 dataType: 'json',
-                type: 'get',
+                type: 'post',
+                data: ndic,
                 contentType: 'application/x-www-form-urlencoded',
                 success: function (data) {
 
@@ -1273,13 +1295,13 @@ require([
                                 numSeries=seriesDic[studyId];
                            }
 
-                            newHtml = '<tr id="' + rowId + '" data-projectid="'+ projectId +'" class="' + pclass + ' ' + cclass +' text_head" onclick="(toggleRows(this, \'studies\', \'study_\', false))">' +
+                            newHtml = '<tr id="' + rowId + '" data-projectid="'+ projectId +'" class="' + pclass + ' ' + cclass +' text_head">' +
                                 //'<td class="col1 project-name">' + projectId + '</td>' +
-                                '<td class="ckbx"><input type="checkbox"></td>' +
+                                '<td class="ckbx"><input type="checkbox" onclick="(toggleRows($(this).parent().parent(), \'studies\', \'study_\', false))"></td>' +
                                  '<td class="col1 case-id">' + patientId + '</td>'+
                                 '<td class="col2 study-id study-id-col" data-study-id="'+studyId+'">' + hrefTxt + '</td>' +
                                 '<td class="col1 study-description">' + studyDescription + '</td>' +
-                                '<td class="col1 numcases">' + numSeries.toString() + '</td>'+
+                                '<td class="col1 numrows">' + numSeries.toString() + '</td>'+
                                 '<td class="ohif open-viewer"><a  href="' + fetchUrl + '" target="_blank"><i class="fa fa-eye"></i></a></td></tr>'
 
                         }
@@ -1499,28 +1521,7 @@ require([
                 }
             }
         }
-    /*
-        var resetSearchScope = function (scopeArr, searchId) {
-            var selectElem = $('#' + searchId)[0];
-            var selIndex = 0;
-            if (scopeArr === window.tcgaColls) {
-                selIndex = 0;
-            } else {
-                selProject = scopeArr[0];
-                selectionArr = $(selectElem).children("option");
-                for (var i = 0; i < selectionArr.length; i++) {
-                    selectItem = selectionArr[i];
-                    if (selProject === selectItem.value) {
-                        selIndex = i;
-                        break;
-                    }
-                }
 
-            }
-            selectElem.selectedIndex = selIndex;
-        }
-
-*/
         var updateSliderSelection = function (inpDiv, displaySet, header, attributeName, isInt) {
             var val = document.getElementById(inpDiv).value;
             var newText = "&emsp;&emsp;" + header + ": " + val;
@@ -1684,12 +1685,18 @@ require([
             url= encodeURI('/explore/')
 
             ndic={'counts_only':'True', 'is_json':'True', 'is_dicofdic':'True', 'data_source_type':($("#data_source_type option:selected").val() || 'S'), 'filters':JSON.stringify(parsedFiltObj) }
+            if (typeof(window.csr) !=='undefined'){
+                ndic['csrfmiddlewaretoken'] = window.csr
+            }
+
+
             let deferred = $.Deferred();
             $.ajax({
                 url: url,
                 data: ndic,
                 dataType: 'json',
                 type: 'post',
+
                 contentType: 'application/x-www-form-urlencoded',
                 success: function (data) {
                     var isFiltered = Boolean($('#search_def p').length>0);
@@ -1867,7 +1874,11 @@ require([
                      */
                     changeAjax(false);
                     deferred.resolve();
+                },
+                error: function(data){
+                    console.log('error loading data');
                 }
+
             });
             return deferred.promise();
         };
@@ -2646,49 +2657,49 @@ require([
             });
 
             $('#' + filterId).find('.check-all').on('click', function () {
-                //$('#' + filterId).find('.checkbox').find('input').prop('checked', true);
-                var filterElems = new Object();
-
-                filterElems = $(this).parentsUntil('.list-group-item, #program_set').filter('.list-group-item__body, .list-group-sub-item__body, #Program').children('ul').children();
-
-                for (var ind =0;ind<filterElems.length;ind++) {
-                    var ckElem = new Object();
-                    if ($(filterElems[ind]).children().filter('.list-group-item__heading').length>0){
-                        ckElem = $(filterElems[ind]).children().filter('.list-group-item__heading').children().filter('input:checkbox')[0];
-                    } else {
-                       ckElem=$(filterElems[ind]).children().filter('label').children().filter('input:checkbox')[0];
+                if (!is_cohort) {
+                    //$('#' + filterId).find('.checkbox').find('input').prop('checked', true);
+                    var filterElems = new Object();
+                    filterElems = $(this).parentsUntil('.list-group-item, #program_set').filter('.list-group-item__body, .list-group-sub-item__body, #Program').children('ul').children();
+                    for (var ind = 0; ind < filterElems.length; ind++) {
+                        var ckElem = new Object();
+                        if ($(filterElems[ind]).children().filter('.list-group-item__heading').length > 0) {
+                            ckElem = $(filterElems[ind]).children().filter('.list-group-item__heading').children().filter('input:checkbox')[0];
+                        } else {
+                            ckElem = $(filterElems[ind]).children().filter('label').children().filter('input:checkbox')[0];
+                        }
+                        ckElem.checked = true;
+                        //$(filterElem).prop('checked') = true;
+                        if (ind < filterElems.length - 1) {
+                            handleFilterSelectionUpdate(ckElem, false, false);
+                        } else {
+                            handleFilterSelectionUpdate(ckElem, true, true);
+                        }
                     }
-                    ckElem.checked= true;
-                  //$(filterElem).prop('checked') = true;
-                  if (ind<filterElems.length-1) {
-                      handleFilterSelectionUpdate(ckElem, false, false);
-                  } else {
-                      handleFilterSelectionUpdate(ckElem, true, true);
-                  }
                 }
             });
 
             $('#' + filterId).find('.uncheck-all').on('click', function () {
-                 //$('#' + filterId).find('.checkbox').find('input').prop('checked', true);
-                var filterElems = new Object();
+              if (!is_cohort){
+                    //$('#' + filterId).find('.checkbox').find('input').prop('checked', true);
+                    var filterElems = new Object();
+                    filterElems = $(this).parentsUntil('.list-group-item, #program_set').filter('.list-group-item__body, .list-group-sub-item__body, #Program').children('ul').children();
+                    for (var ind = 0; ind < filterElems.length; ind++) {
+                        var ckElem = new Object();
+                        if ($(filterElems[ind]).children().filter('.list-group-item__heading').length > 0) {
+                            ckElem = $(filterElems[ind]).children().filter('.list-group-item__heading').children().filter('input:checkbox')[0];
+                        } else {
+                            ckElem = $(filterElems[ind]).children().filter('label').children().filter('input:checkbox')[0];
+                        }
 
-                filterElems = $(this).parentsUntil('.list-group-item, #program_set').filter('.list-group-item__body, .list-group-sub-item__body, #Program').children('ul').children();
-
-                for (var ind =0;ind<filterElems.length;ind++) {
-                    var ckElem = new Object();
-                    if ($(filterElems[ind]).children().filter('.list-group-item__heading').length>0){
-                        ckElem = $(filterElems[ind]).children().filter('.list-group-item__heading').children().filter('input:checkbox')[0];
-                    } else {
-                       ckElem=$(filterElems[ind]).children().filter('label').children().filter('input:checkbox')[0];
-                    }
-
-                  ckElem.checked = false;
-                    if (ind<filterElems.length-1) {
-                      handleFilterSelectionUpdate(ckElem, false, false);
-                  } else{
-                      handleFilterSelectionUpdate(ckElem, true, true);
-                  }
-                }
+                        ckElem.checked = false;
+                        if (ind < filterElems.length - 1) {
+                            handleFilterSelectionUpdate(ckElem, false, false);
+                        } else {
+                            handleFilterSelectionUpdate(ckElem, true, true);
+                        }
+                   }
+              }
             });
         };
 
@@ -2942,7 +2953,7 @@ require([
         save_anonymous_selection_data();
     });
 
-     var cohort_loaded = false;
+     cohort_loaded = false;
      function load_preset_filters() {
          if (is_cohort && !cohort_loaded) {
              var loadPending = load_filters(cohort_filters);
@@ -2950,7 +2961,8 @@ require([
                  console.debug("Load pending complete.");
                  cohort_loaded = true;
                  $('input[type="checkbox"]').prop("disabled", "disabled");
-
+                 $('#projects_table').find('input:checkbox').removeAttr("disabled");
+                 //$('.check-all').prop("disabled","disabled");
                  // Re-enable checkboxes for export manifest dialog, unless not using social login
                  if (user_is_social)
                  {
@@ -3011,8 +3023,11 @@ require([
      }
 
       $(document).ready(function () {
+          //const csrftoken = Cookies.get('csrftoken');
+
            // $('#proj_table').DataTable();
            // window.filterObj.collection_id = window.tcgaColls;
+            //var cohort_loaded = false;
             window.selItems = new Object();
             window.selItems.selStudies = new Object();
             window.selItems.selCases = new Object();

--- a/templates/cohorts/cohort_details.html
+++ b/templates/cohorts/cohort_details.html
@@ -23,6 +23,7 @@
 {% block header %}
     <link type="text/css" rel="stylesheet" href="{% static 'css/search.css' %}">
     <link type="text/css" rel="stylesheet" href="{% static 'css/jquery-ui.min.css' %}">
+    <link type="text/css" rel="stylesheet" href="{% static 'css/spinner.css' %}">
     <!-- <script src="https://d3js.org/d3.v5.min.js"></script> -->
     <!-- <script type="text/javascript" src="{% static 'js/libs/d3.v5.min.js' %}"></script> -->
 {% endblock %}
@@ -56,11 +57,7 @@
 {% include "cohorts/export-manifest-modal.html" with export_uri=export_uri %}
 
 <script>
-   window.selItems = new Object();
-   window.selItems.selProjects = new Array();
-   window.selItems.selStudies = new Object();
-   window.collection = {{ collections|tojson|safe }};
-   window.programs = {{ programs|tojson|safe }};
+   var cohort_loaded = true
 </script>
 
 {% with is_cohort=True %}

--- a/templates/cohorts/cohort_list.html
+++ b/templates/cohorts/cohort_list.html
@@ -98,10 +98,14 @@
                             </td>
                             <td class="name-col">
                                 {% if only_active_versions %}
-                                <a href="{% url 'cohort_details' cohort.id %}"
-                                   title="View Cohort Details in the Data Explorer">
-                                    {{ cohort.name }}
-                                </a>
+                                 <form name="getCohort" method="POST" action="{% url 'cohort_details' cohort.id %}">
+                                    {% csrf_token %}
+                                     <a href="javascript:document.getCohort.submit()"
+                                       title="View Cohort Details in the Data Explorer">
+                                       {{ cohort.name }}
+                                    </a>
+                                 </form>
+
                                 {% else %}
                                     <span title="Cohorts with inactive data versions cannot be viewed in the Data Explorer.">{{ cohort.name }}</span>
                                 {% endif %}

--- a/templates/cohorts/cohort_list.html
+++ b/templates/cohorts/cohort_list.html
@@ -6,6 +6,7 @@
 {% block header %}
     <link rel="stylesheet" href="{% static  'css/jquery-ui.min.css' %}">
     <link type="text/css" rel="stylesheet" href="{% static 'css/spinner.css' %}">
+    <link type="text/css" rel="stylesheet" href="{% static 'css/cohort-list.css' %}">
 {% endblock %}
 
 {% block title %}
@@ -26,7 +27,29 @@
 {% url 'cohort_manifest_base' as export_uri %}
 {% include "cohorts/export-manifest-modal.html" with export_uri=export_uri %}
 
-<div id = "dialog-1" title = "Dialog Title goes here..." style="display:inline-block">This my first jQuery UI Dialog!</div>
+<div id="version_d" tabindex="-1"  class="ui-dialog ui-corner-all ui-widget ui-widget-content ui-front ui-draggable ui-resizable" aria-describedby="dialog-1" aria-labelledby="ui-id-1">
+        <div class="ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix ui-draggable-handle">
+             <span id="ui-id-1" class="ui-dialog-title">Comparing Versions of Cohort -1</span>
+             <button onclick="$('#version_d').hide()"><i class="fa fa-times"></i></button>
+        </div>
+    <div id="dialog-1" style="display: inline-block; width: auto; min-height: 90px; max-height: none; height: auto;" class="ui-dialog-content ui-widget-content">
+             <table class="table"><tbody>
+                 <tr><th></th><th>Original Version</th><th>Current Version</th></tr>
+             <tr><td># Cases</td> <td class="case_o">XXXX</td> <td class="case_c">XXXX</td> </tr>
+                 <tr><td># Studies</td> <td class="study_o">XXXX</td> <td class="study_c">XXXX</td> </tr>
+                 <tr><td># Series</td> <td class="series_o">XXXX</td> <td class="series_c">XXXX</td> </tr>
+
+             </tbody></table>
+             <br><button onclick="location.href = '/explore/?cohort_id=-1';">Load New Version</button>
+         </div>
+    <div class="ui-resizable-handle ui-resizable-n" style="z-index: 90;"></div>
+
+</div>
+
+
+</div>
+
+</div>
 <div class="spinner" style="display: none;"><i class="fa fa-spinner fa-spin spin"></i></div>
 
 <div class="container-fluid">
@@ -100,7 +123,7 @@
                                 {% if only_active_versions %}
                                  <form name="getCohort" method="POST" action="{% url 'cohort_details' cohort.id %}">
                                     {% csrf_token %}
-                                     <a href="javascript:document.getCohort.submit()"
+                                     <a href="#" onclick="$(this).parent().submit()"
                                        title="View Cohort Details in the Data Explorer">
                                        {{ cohort.name }}
                                     </a>

--- a/templates/idc/explore_data_core.html
+++ b/templates/idc/explore_data_core.html
@@ -422,6 +422,7 @@
                              {% endif %}
                          </div>
                          <div class="panel-body">
+                             <input id="filt_txt" type="hidden" value="">
                              <div id ="search_def"><span class="placeholder">&nbsp;</span></div>
                              <div id="search_def_warn" style="display:none">Note: TCGA.* filters only apply to TCGA collections</div>
                          </div>

--- a/templates/idc/explore_data_core.html
+++ b/templates/idc/explore_data_core.html
@@ -7,10 +7,13 @@
    window.selItems.selStudies = new Object();
    window.collection = {{ collections|tojson|safe }};
    window.programs = {{ programs|tojson|safe }};
+   window.csr = "{{  csrf_token }}";
 </script>
 
 
 <div class="container-fluid">
+
+
     <div class ="row">
         <div class="tab-content data-tab-content">
             <input id="number_ajax" type="hidden" value="0">

--- a/templates/idc/explore_data_core.html
+++ b/templates/idc/explore_data_core.html
@@ -52,7 +52,7 @@
 
                                      </div>
                                      <div id="Program" class="collapse filter-panel collection-list">
-                                     <p><input id="hide-zeros" type="checkbox" value="hide-zeros" onchange="hideColl(this)"> Hide collections with 0 cases</p>
+                                     <p><input id="hide-zeros" class="hide-zeros" type="checkbox" value="hide-zeros" onchange="hideColl(this)"> Hide collections with 0 cases</p>
                                          {% with programs.items|length|add:"-5" as more %}
                                          <p class="more-checks" style="display: block;" ><a class="show-more">show {{ more }} more</a><span class="checks"><a class="check-all">Check All</a> / <a class="uncheck-all">Uncheck All</a></span></p>
                                          <p class="less-checks" style="display: none;" > <a class="show-less">show less</a><span class="checks"><a class="check-all">Check All</a> / <a class="uncheck-all">Uncheck All</a></span></p>
@@ -161,7 +161,7 @@
                                 <h4 class="panel-title">Search Configuration
                                     <div  class="tooltip_chart_info" style="float:right"><i class="fa fa-info-circle"></i></div>
                                 </h4>
-                                <br><span><input id="hide-zeros" type="checkbox" value="hide-zeros" onchange="hideAtt(this)"> Hide attribute values with 0 cases</span>
+                                <br><span><input id="hide-zeros" class="hide-zeros" type="checkbox" value="hide-zeros" onchange="hideAtt(this)"> Hide attribute values with 0 cases</span>
                             </div>
 
                             <ul class="nav nav-tabs nav-tabs-filters" role="tablist">

--- a/templates/idc/explore_demo.html
+++ b/templates/idc/explore_demo.html
@@ -78,10 +78,7 @@
 {% block content %}
 
 <script>
-   window.selItems = new Object();
-   window.selItems.selProjects = new Array();
-   window.selItems.selStudies = new Object();
-   window.collection = {{ collections|tojson|safe }};
+   var cohort_loaded  = false;
 </script>
 
 {% include "idc/explore_data_core_demo.html" %}


### PR DESCRIPTION
More WebApp development to fix bugs and handle new collections. Fixes for specific issues:
[1. ](https://github.com/ImagingDataCommons/IDC-WebApp/issues/629) Disabling Select All buttons on cohort details page
[2.](https://github.com/ImagingDataCommons/IDC-WebApp/issues/623) Enabling table navigation/ series and study image viewing from the cohort details page
[3.](https://github.com/ImagingDataCommons/IDC-WebApp/issues/622) Change filter requests from GET to POST to allow longer filter queries
[4.](https://github.com/ImagingDataCommons/IDC-WebApp/issues/555) Table rows fetched per query  set to 3000 to accommodate VICTRE. Three specific bugs in table selections fixed. 1) When cases are selected from the case table, the # of Studies is now used to determine record limit (# of Series were being used). 2) If a set of rows are selected that have too many records to fetch at once, the check box is reset to unchecked for each selected row (checkboxes were being checked even when query was cancelled). 3) Checking into a table, rather than specifically checking the checkbox, was causing an aberrant code execution where none was expected. This was due to legacy code.
5. Refactored versioning popup on cohort list page. The dialog popup was sometime formatted incorrectly.
6. Fixed formating of collection name/count tuples. The counts were sometimes being truncated at the bottom when the parent div did not expand to include a needed 2nd line. Related to the infamous ['clearfix'](https://www.w3schools.com/howto/howto_css_clearfix.asp) hack 