### PR TITLE
Sprint 32 gw

### DIFF
--- a/idc/settings.py
+++ b/idc/settings.py
@@ -295,6 +295,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'request_logging.middleware.LoggingMiddleware',
     'offline.middleware.OfflineMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
 ]
 
 ROOT_URLCONF = 'idc.urls'

--- a/static/css/search.css
+++ b/static/css/search.css
@@ -468,8 +468,13 @@ svg {
     clear: both;
 }
 
+
 .list-group-item__heading:after {
     content: "";
     display:table;
     clear: both;
+}
+
+.ui-slider{
+    margin-bottom: 18px;
 }

--- a/static/js/image_search.js
+++ b/static/js/image_search.js
@@ -121,6 +121,7 @@ require([
     };
 
     window.setSlider = function (slideDiv, reset, strt, end, isInt, updateNow) {
+        $('#' + slideDiv).closest('.hasSlider').find('.slider-message').addClass('notDisp');
         parStr=$('#'+slideDiv).data("attr-par");
         var max = $('#' + slideDiv).slider("option", "max");
         var divName = slideDiv.replace("_slide","");
@@ -175,11 +176,7 @@ require([
                 window.filterObj[filtAtt] = new Object();
             }
             window.filterObj[filtAtt]['rng'] = attVal;
-            if (end<max) {
-                window.filterObj[filtAtt]['type'] = 'ebtw';
-            } else {
-                window.filterObj[filtAtt]['type'] = 'ebtwe';
-            }
+            window.filterObj[filtAtt]['type'] = 'ebtwe';
         }
         if (updateNow) {
             mkFiltText();
@@ -320,7 +317,7 @@ require([
     }
 
     window.addNone = function(elem, parStr, updateNow) {
-            var id = parStr+$(elem).parent().parent()[0].id+"_rng";
+            var id = parStr+$(elem).closest('.list-group-item__body')[0].id+"_rng";
 
             if (elem.checked){
                 if (!(id in window.filterObj)) {
@@ -359,9 +356,10 @@ require([
             position: 'absolute',
             top: -25,
             left: 0,
-            transform: 'translateX(-50%)'
+            transform: 'translateX(-50%)',
 
         });
+
 
          var tooltipR = $('<div class="slide_tooltip slide_tooltipB tooltipR" />').text('stuff').css({
            position: 'absolute',
@@ -406,9 +404,8 @@ require([
         if ($('#'+divName).find('#'+inpName).length===0){
             $('#' + divName).append('<input id="' + inpName + '" type="text" value="' + strtInp + '" style="display:none">');
         }
-        if ($('#'+divName).find('.reset').length===0){
-            $('#' + divName).append(  '<button class="reset" style="display:block;margin-top:18px" onclick=\'setSlider("' + slideName + '",true,0,0,' + String(isInt) + ', true,"'+parStr+'")\'>Clear Slider</button>');
-        }
+
+
         if (isActive){
             $('#'+divName).find('.reset').removeClass('disabled');
         }
@@ -417,12 +414,6 @@ require([
         }
 
          $('#'+slideName).append(labelMin);
-
-         if (wNone){
-            $('#' + divName).append( '<span class="noneBut"><input type="checkbox"   onchange="addNone(this, \''+parStr+'\', true)"> None </span>');
-            $('#' + divName).find('.noneBut').find(':input')[0].checked = checked
-
-         }
 
 
         $('#' + slideName).slider({
@@ -447,7 +438,6 @@ require([
                 $('#' + slideName).addClass('used');
                 var val = $('#' + inpName)[0].value;
                 var valArr = val.split('-');
-
                 window.setSlider(slideName, false, valArr[0], valArr[1], isInt, true);
 
             }
@@ -485,11 +475,6 @@ require([
         $('#'+slideName).append(labelMax);
         $('#'+slideName).addClass('space-top-15');
 
-
-        /*$('#'+ divName+'_list').addClass('hide');
-        $('#'+ divName).find('.more-checks').addClass('hide');
-        $('#'+ divName).find('.less-checks').addClass('hide');
-        $('#'+ divName).find('.hide-zeros').addClass('hide');*/
     };
 
     var updateTablesAfterFilter = function (collFilt, collectionsData){
@@ -2800,22 +2785,28 @@ require([
             var isActive = $(this).hasClass('isActive');
             var wNone = $(this).hasClass('wNone');
             var checked = ($(this).find('.noneBut').length>0) ? $(this).find('.noneBut').find(':input')[0].checked : false;
+            var txtLower = ($(this).find('.sl_lower').length>0) ? $(this).find('.sl_lower').val():'';
+            var txtUpper = ($(this).find('.sl_lower').length>0) ? $(this).find('.sl_upper').val():'';
+            var cntrNotDisp = ($(this).find('.cntr').length>0) ?$(this).find('.cntr').hasClass('notDisp'):true;
+
 
             if (initialCreation){
                 var heading = $(this).prop('id') + '_heading';
-                $('#'+heading).find('.controls').remove();
+                $('#'+heading).find('.fa-cog').attr('title', 'Control slider');
+                $('#'+heading).find('.fa-search').remove();
+
+                $(this).find('.more-checks').remove();
+                $(this).find('.less-checks').remove();
+                $(this).find('.sorter').remove();
                 $('#'+this.id+'_list').addClass('hide');
-                $(this).find('.more-checks').addClass('hide');
-                $(this).find('.less-checks').addClass('hide');
-                $(this).find('.sorter').addClass('hide');
             }
             else {
                 var slideDivId = $(this).prop('id') + '_slide';
                 curmin = $(this).attr('data-curmin');
                 curmax = $(this).attr('data-curmax');
                 $(this).find('#' + slideDivId).remove();
-                $(this).find('.reset').remove();
-                $(this).find('.noneBut').remove();
+                $(this).find('.cntr').remove();
+                //$(this).find('.noneBut').remove();
                 var inpName = $(this).prop('id') + '_input';
                 $(this).find('#'+inpName).remove();
                 if (hideZeros) {
@@ -2848,9 +2839,46 @@ require([
             if (addSlider) {
                 $(this).addClass('hasSlider');
                 mkSlider($(this).prop('id'), min, max, 1, true, wNone, parStr, $(this).data('filter-attr-id'), $(this).data('filter-display-attr'), lower, upper, isActive,checked);
+                var cntrlDiv=$('<div class="cntr"></div>');
+                cntrlDiv.append('<div class="sliderset" style="display:block;margin-bottom:8px">Lower: <input type="text" style="display:inline" size="5" class="sl_lower" value="'+ txtLower + '">' +
+                    ' Upper: <input class="sl_upper" type="text" style="display:inline" size="5" class="upper" value="' + txtUpper + '">' +
+                    '<div class="slider-message notDisp" style="color:red"><br>Please set lower and upper bounds to numeric values with the upper value greater than the lower, then press Return in either text box. </div></div>')
+                cntrlDiv.append(  '<button class="reset" style="display:block;" onclick=\'setSlider("'+ this.id + '_slide", true,0,0,true, true,"'+parStr+'")\'>Clear Slider</button>');
+                if (wNone){
+                   cntrlDiv.append( '<span class="noneBut"><input type="checkbox"   onchange="addNone(this, \''+parStr+'\', true)"> None </span>');
+                   cntrlDiv.find('.noneBut').find(':input')[0].checked = checked;
+                }
+                if (cntrNotDisp){
+                    cntrlDiv.addClass('notDisp');
+                }
+                $(this).append(cntrlDiv);
+                $(this).find('.sliderset').keypress(function(event){
+                   var keycode = (event.keyCode ? event.keyCode : event.which);
+                   if(keycode == '13'){
+
+                   try {
+                      var txtlower = parseFloat($(this).parent().find('.sl_lower').val());
+                      var txtupper = parseFloat($(this).parent().find('.sl_upper').val());
+                      if (txtlower<=txtupper){
+                        setSlider($(this).closest('.hasSlider')[0].id+"_slide", false, txtlower, txtupper, false,true);
+                      }
+                      else{
+                          $(this).closest('.hasSlider').find('.slider-message').removeClass('notDisp');
+
+                      }
+                   }
+                  catch(error){
+                    $(this).closest('.hasSlider').find('.slider-message').removeClass('notDisp');
+                    console.log(error);
+                  }
+               }
+              });
+
             } else{
                 $(this).removeClass('hasSlider');
+
             }
+
         });
      };
 
@@ -2911,7 +2939,7 @@ require([
                       });
                   }
                 if (attValueFoundInside){
-                    $(selEle).collapse('show');
+                    //$(selEle).collapse('show');
                     $(selEle).find('.show-more').triggerHandler('click');
                     $(selEle).parents('.tab-pane.search-set').length > 0 && $('a[href="#' + $(selector).parents('.tab-pane.search-set')[0].id + '"]').tab('show');
                 }

--- a/static/js/image_search.js
+++ b/static/js/image_search.js
@@ -216,7 +216,6 @@ require([
                         collection.push(colName);
                     }
                 }
-
             } else if (curKey.endsWith('_rng')) {
                 var realKey = curKey.substring(0, curKey.length - 4).split('.').pop();
                 var disp = $('#' + realKey + '_heading').children().children('.attDisp')[0].innerText;
@@ -487,10 +486,10 @@ require([
         $('#'+slideName).addClass('space-top-15');
 
 
-        $('#'+ divName+'_list').addClass('hide');
+        /*$('#'+ divName+'_list').addClass('hide');
         $('#'+ divName).find('.more-checks').addClass('hide');
         $('#'+ divName).find('.less-checks').addClass('hide');
-        $('#'+ divName).find('.hide-zeros').addClass('hide');
+        $('#'+ divName).find('.hide-zeros').addClass('hide');*/
     };
 
     var updateTablesAfterFilter = function (collFilt, collectionsData){
@@ -1910,7 +1909,7 @@ require([
 
                     updateTablesAfterFilter(collFilt, data.origin_set.All.attributes.collection_id);
 
-                    if ($('#hide-zeros')[0].checked) {
+                    if ($('.search-configuration').find('#hide-zeros')[0].checked) {
                         addSliders('search_orig_set', false, true, '');
                         addSliders('quantitative', false, true, '');
                         addSliders('tcga_clinical', false, true, 'tcga_clinical.');
@@ -2679,7 +2678,6 @@ require([
 
     var filterItemBindings = function (filterId) {
 
-
         $('#' + filterId).find('input:checkbox').not('#hide-zeros').on('click', function () {
             handleFilterSelectionUpdate(this, true, true);
         });
@@ -2793,11 +2791,6 @@ require([
 
     var addSliders = function(id,initialCreation,hideZeros, parStr){
         $('#'+id).find('.list-group-item__body.isQuant').each(function() {
-            $(this).find('.more-checks').addClass('hide');
-            $(this).find('.less-checks').addClass('hide');
-            $(this).find('.sorter').addClass('hide');
-            //var min = Math.ceil($(this).data('min') * 1000)/1000;
-            //var min = Math.floor($(this).data('min'));
 
             var min = Math.floor(parseInt($(this).attr('data-min')));
             var max = Math.ceil(parseInt($(this).attr('data-max')));
@@ -2811,25 +2804,24 @@ require([
             if (initialCreation){
                 var heading = $(this).prop('id') + '_heading';
                 $('#'+heading).find('.controls').remove();
+                $('#'+this.id+'_list').addClass('hide');
+                $(this).find('.more-checks').addClass('hide');
+                $(this).find('.less-checks').addClass('hide');
+                $(this).find('.sorter').addClass('hide');
             }
             else {
-
                 var slideDivId = $(this).prop('id') + '_slide';
                 curmin = $(this).attr('data-curmin');
                 curmax = $(this).attr('data-curmax');
-
                 $(this).find('#' + slideDivId).remove();
                 $(this).find('.reset').remove();
-
                 $(this).find('.noneBut').remove();
                 var inpName = $(this).prop('id') + '_input';
                 $(this).find('#'+inpName).remove();
-
                 if (hideZeros) {
                     if ( ( (curmin === 'NA') || (curmax === 'NA')) && !isActive ){
                         addSlider = false;
                         $(this).removeClass('hasSlider');
-                        //$(this).removeClass('isActive');
                     } else if (isActive){
                         if (curmin === 'NA') {
                                 min = lower;
@@ -2846,14 +2838,10 @@ require([
                             max = Math.ceil(curmax);
                             lower=min;
                             upper=max;
-                            //$(this).attr('data-curminrng', lower);
-                            //$(this).attr('data-curmaxrng', upper);
                     }
                 } else if (!isActive){
                     lower=min;
                     upper=max;
-                    //$(this).attr('data-curminrng', lower);
-                    //$(this).attr('data-curmaxrng', upper);
                 }
             }
 
@@ -2862,7 +2850,6 @@ require([
                 mkSlider($(this).prop('id'), min, max, 1, true, wNone, parStr, $(this).data('filter-attr-id'), $(this).data('filter-display-attr'), lower, upper, isActive,checked);
             } else{
                 $(this).removeClass('hasSlider');
-
             }
         });
      };
@@ -3151,7 +3138,13 @@ require([
         $('.spinner').hide();
     });
 
+
     $(document).ready(function () {
+
+        $('#body').on("unload", function(){
+            alert('hi');
+        })
+
         window.selItems = new Object();
         window.selItems.selStudies = new Object();
         window.selItems.selCases = new Object();

--- a/templates/idc/explore_data_core.html
+++ b/templates/idc/explore_data_core.html
@@ -397,13 +397,12 @@
                                                                                     ){% endif %}</span> <span
                                                                                 class="notDisp noCase"> (0 cases)</span>
                                                                         </a>
-                                                                        {% if attr_setV.name != 'quantitative' %}
-                                                                            <span class="controls">
-                                                                 <i class="fa-solid fa-cog" title="Sort results"></i>
-                                                                 <i class="fa-solid fa-search"
-                                                                    title="Filter displayed values"></i>
-                                                             </span>
-                                                                        {% endif %}
+
+                                                                        <span class="controls">
+                                                                          <i class="fa-solid fa-cog" title="Sort results"></i>
+                                                                          <i class="fa-solid fa-search" title="Filter displayed values"></i>
+                                                                        </span>
+
                                                                     </div>
 
                                                                     <div id="{{ attr.name }}"


### PR DESCRIPTION
Range value filters are now inclusive of both the upper and lower range values. The filters had been inclusive on the lower end, exclusive on the upper end to match how the 'slices' are constructed in pie chart displays. This is in resolution of #922.

Text boxes are included for all sliders to directly enter quantitative filter limits. The user must press 'Return' within either of the text boxes after entering appropriate numbers to trigger the filter.  This is in reponse to #932   