### PR TITLE
Release 37 / v15

### DIFF
--- a/static/js/cohorts/export-manifest.js
+++ b/static/js/cohorts/export-manifest.js
@@ -209,7 +209,12 @@ require([
                 file_name.attr("name-base", "cohort_" + cohort_ids.join("_") + $('#export-manifest-modal').data('file-timestamp'));
             }
         }
-        $('.cmd-file-name').text(file_name.attr("name-base")+"_"+$('input.loc_type:checked').val());
+        let manifest_filename = file_name.attr("name-base")+"_"+$('input.loc_type:checked').val();
+        let endpoint_url = ($('input.loc_type:checked').val() === "aws" ? "https://s3.amazonaws.com" : "https://storage.googleapis.com");
+        let s5cmd_text = `s5cmd --no-sign-request --endpoint-url ${endpoint_url} run ${manifest_filename}.s5cmd`;
+
+        $('.s5cmd-text').text(s5cmd_text);
+        $('.s5cmd.copy-this').attr("content",s5cmd_text);
     }
 
     var update_download_manifest_buttons = function(clicked){

--- a/templates/cohorts/export-manifest-modal.html
+++ b/templates/cohorts/export-manifest-modal.html
@@ -150,7 +150,10 @@
                                        data-target="#external-web-warning">install s5cmd <i class="fa-solid fa-external-link external-link-icon" aria-hidden="true"></i></a>,
                                     then run the following command:
                                     <br />
-                                    <span class="code">s5cmd --no-sign-request --endpoint-url https://storage.googleapis.com run <span class="cmd-file-name"></span>.s5cmd</span>
+                                    <span class="code s5cmd-text">s5cmd --no-sign-request --endpoint-url https://endpoint_url run file_name.s5cmd</span>
+                                    <a role="button" class="s5cmd copy-this" content=""  title="Copy command to clipboard">
+                                        ( <i class="fa-solid fa-copy" aria-hidden="true"></i> )
+                                    </a>
                                 </p>
 <!--
                                 <div class="s5cmd-file-name manifest-name">


### PR DESCRIPTION
- The s5cmd displayed in the manifest download dialog will now use the proper --endpoint-url value (#1222)
- This was also the problem with #1206 
- Provided a button for copying the command to the clipboard