### PR TITLE
Vagrant changes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,7 @@ Vagrant.configure(2) do |config|
   # WebApp ports
   config.vm.network "forwarded_port", guest: 8086, host: 8086
   config.vm.network "forwarded_port", guest: 8006, host: 8006
+  config.vm.network "forwarded_port", guest: 22, host: 2200, id: "ssh"
 
   config.vm.synced_folder ".", "/home/vagrant/www"
   config.vm.synced_folder "../", "/home/vagrant/parentDir"


### PR DESCRIPTION
- Move IDC to 2200 (from default 2222) in preparation for Vagrant updates to Pycharm 2024 versions