### PR TITLE
Remove incorrect statements from the privacy policy

### DIFF
--- a/templates/idc/privacy.html
+++ b/templates/idc/privacy.html
@@ -42,10 +42,7 @@
                     <li>Date and time of your visit</li>
                     <li>Pages you visited</li>
                     <li>Address of the Web site that connected you to the IDC site (such as google.com or bing.com)</li>
-                    <li>Email address associated to your Google Account</li>
-                    <li>Name (as available in your Google Account profile)</li>
                     <li>Information about what datasets are visited, linked to the IP address used to visit it</li>
-                    <li>Information about the datasets that were accessed from Google Cloud Storage requester pays, and the associated IP address, and Collection ID</li>
                 </ul>
                 <p>
                     We use this information to measure the number of visitors to our site and its various sections and datasets to help make our site more useful to visitors.


### PR DESCRIPTION
We do not collect (and have no means to collect) email or name associated with the user account, unless the user chooses to log in.