### PR TITLE
Update explore banner to match landing banner

### DIFF
--- a/templates/idc/explore.html
+++ b/templates/idc/explore.html
@@ -41,10 +41,10 @@
                     <div class="row ">
                         <div class="col-xs-1"></div>
                         <div class="col-xs-10">
-                            <b>Need personalized help? Sign up for a 1-on-1 meeting with an IDC team member here:
-                                <a class="external-link" href="" url="https://tinyurl.com/idc-help-request"
+                            <b>Natural language interface to IDC:
+                                <a class="external-link" href="" url="https://github.com/ImagingDataCommons/idc-claude-skill"
                                    data-toggle="modal" data-target="#external-web-warning">
-                                    https://tinyurl.com/idc-help-request
+                                    https://github.com/ImagingDataCommons/idc-claude-skill
                                 </a> <i class="fa-solid fa-external-link external-link-icon" aria-hidden="true"></i></b>.
                         </div>
                         <div class="col-xs-1">


### PR DESCRIPTION
## Summary
Updated the alert banner in explore.html to match the banner in landing.html. The banner now promotes the Claude skill with a GitHub link instead of the help request form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)